### PR TITLE
Small fix for people with a custom startup.jl

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1350,6 +1350,7 @@ end
 
 if Sys.isunix()
     julia = joinpath(Sys.BINDIR, "julia")
+    julia = `$julia --startup-file=no`
     @testset "Examples" begin
         # Check examples work without error.
         cd(joinpath(dirname(@__FILE__), "..", "example")) do


### PR DESCRIPTION
```
ERROR: LoadError: ArgumentError: Package OhMyREPL not found in current path:
- Run `import Pkg; Pkg.add("OhMyREPL")` to install the OhMyREPL package.

Stacktrace:
 [1] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:893
in expression starting at /home/el_oso/.julia/config/startup.jl:19
listlinks.jl: Test Failed at /home/el_oso/.julia/packages/EzXML/ZNwhK/test/runtests.jl:1382
  Expression: false
Stacktrace:
 [1] macro expansion
   @ ~/.julia/packages/EzXML/ZNwhK/test/runtests.jl:1382 [inlined]
 [2] macro expansion
   @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
 [3] (::var"#13#14")()
   @ Main ~/.julia/packages/EzXML/ZNwhK/test/runtests.jl:1377
Test Summary:  | Fail  Total
Examples       |    3      3
  primates.jl  |    1      1
  julia2xml.jl |    1      1
  listlinks.jl |    1      1
ERROR: LoadError: Some tests did not pass: 0 passed, 3 failed, 0 errored, 0 broken.
in expression starting at /home/el_oso/.julia/packages/EzXML/ZNwhK/test/runtests.jl:1351
ERROR: Package EzXML errored during testing
```

This fixes these kind of errors due to the lack of `--startup-file=no`  on the julia command line
