### PR TITLE
Readme: link docs for caveat on xpath<>namespaces combination

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ Constructors:
 * `EzXML.Node` type: `XMLDocumentNode(version="1.0")`, `HTMLDocumentNode(uri, externalID)`, `ElementNode(name)`, `TextNode(content)`, `CommentNode(content)`, `CDataNode(content)`, `AttributeNode(name, value)`, `DTDNode(name, [systemID, [externalID]])`
 
 Queries:
-* XPath: `findall(xpath, doc|node)`, `findfirst(xpath, doc|node)`, `findlast(xpath, doc|node)`
+* XPath: `findall(xpath, doc|node)`, `findfirst(xpath, doc|node)`, `findlast(xpath, doc|node)`\
+  (Note the caveat on the combination of XPath and namespaces in the [manual](https://juliaio.github.io/EzXML.jl/stable/manual/#XPath-1))
+
 
 Examples
 --------


### PR DESCRIPTION
For discoverability.

Related: 
- https://github.com/JuliaIO/EzXML.jl/issues/137

(which is the only google result for `Warning: ignored the empty prefix for 'http://www.w3.org/2000/svg'; expected to be non-empty`)