### PR TITLE
Ensure that @check always clear error stack.

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -110,7 +110,6 @@ function parsehtml(htmlstring::AbstractString)
         Ptr{_Node},
         (Cstring, Cint, Cstring, Cstring, Cint),
         htmlstring, sizeof(htmlstring), url, encoding, options) != C_NULL
-    show_warnings()
     return Document(doc_ptr)
 end
 
@@ -172,7 +171,6 @@ function readhtml(filename::AbstractString)
         Ptr{_Node},
         (Cstring, Cstring, Cint),
         filename, encoding, options) != C_NULL
-    show_warnings()
     return Document(doc_ptr)
 end
 
@@ -193,7 +191,6 @@ function readhtml(input::IO)
         Ptr{_Node},
         (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Cstring, Cstring, Cint),
         readcb, closecb, context, uri, encoding, options) != C_NULL
-    show_warnings()
     return Document(doc_ptr)
 end
 

--- a/src/error.jl
+++ b/src/error.jl
@@ -51,6 +51,9 @@ macro check(ex)
         if !$(ex)
             throw_xml_error()
         end
+        if !isempty(XML_GLOBAL_ERROR_STACK)
+            show_warnings()
+        end
         ret
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,15 @@ end
         @test version(doc) == "1.0"
         @test hasencoding(doc)
         @test encoding(doc) == "UTF-8"
+
+        # handle invalid xmlns
+        invalid_xmlns = joinpath(dirname(@__FILE__), "sample1.invalid_xmlns.xml")
+        doc, messages = capture_logging_messages() do
+            readxml(invalid_xmlns)
+        end
+        @test isa(doc, EzXML.Document)
+        @test occursin("Warning: XMLError: xmlns: URI This.is.invalid is not absolute from XML Namespace module (code: 100, line: 2)", messages)
+        @test isempty(EzXML.XML_GLOBAL_ERROR_STACK)
     end
 
     @testset "HTML" begin

--- a/test/sample1.invalid_xmlns.xml
+++ b/test/sample1.invalid_xmlns.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<story xmlns="This.is.invalid">
+  <storyinfo>
+    <author>John Fleck</author>
+    <datewritten>June 2, 2002</datewritten>
+    <keyword>example keyword</keyword>
+  </storyinfo>
+  <body>
+    <headline>This is the headline</headline>
+    <para>This is the body text.</para>
+  </body>
+</story>


### PR DESCRIPTION
## References
This PR is created to solve issue #185. It should also help with issue #180 

## Description
I have tried to make a slightly more general fix. `@check` will now handle elements in `XML_GLOBAL_ERROR_STACK` also when the ccall completes as expected. These elements will be handled as warnings. This also allows us to remove the `show_warnings` from the html readers and just have it as a general part of `@check`. Positive side note is that 'EzXML' now can parse XMLs with invalid xmlns. 

A test cases have been added to ensure that it solves the original issue.
