### PR TITLE
Cap compatibility of XML2_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,5 +9,5 @@ XML2_jll = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
 
 [compat]
 Printf = "1.3"
-XML2_jll = "2.9"
+XML2_jll = "2.9.9 - 2.13"
 julia = "1.6"


### PR DESCRIPTION
Reflect changes in https://github.com/JuliaRegistries/General/pull/128961 

https://github.com/GNOME/libxml2/blob/master/NEWS contains a list of features and functions that have been removed in 2.14.

> Metadata about the HTML4 content model was removed from the htmlElemDesc
> struct and related functions were deprecated.
> 
> The FTP module and related functions were removed.
> 
> Support for the range and point extensions of the xpointer() scheme
> was removed. The rest of the XPointer implementation isn't affected.
> The xpointer() scheme now behaves like the xpath1() scheme.
> 
> Several legacy symbols and the functions in xmlunicode.h were removed.
> 
> ELF version information was removed.
> 
> The shell was moved from libxml2 to xmllint. Several related functions
> are no longer available.

Tests for EzXML are also now failing.